### PR TITLE
Fix typo in permission docs

### DIFF
--- a/lib/guardian/permissions.ex
+++ b/lib/guardian/permissions.ex
@@ -34,7 +34,7 @@ defmodule Guardian.Permissions do
                            }
                          }
 
-    use Guardian.Permissions, :encoding: Guardian.Permissions.BitwiseEncoding
+    use Guardian.Permissions, encoding: Guardian.Permissions.BitwiseEncoding
     # Per default permissions will be encoded Bitwise, but other encoders also exist
     #  * Guardian.Permissions.TextEncoding
     #  * Guardian.Permissions.AtomEncoding


### PR DESCRIPTION
Just a small typo fix for the permission docs